### PR TITLE
Corrected wrong repo owner in README (sff1019)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ This is a vim colorscheme that is inspired by marvel's joker.
 First, add one of the lines, depending on your plugin manager.
 ```
 " vim-plug
-Plug 'whatyouhide/vim-joker'
+Plug 'sff1019/vim-joker'
 " NeoBundle
-NeoBundle 'whatyouhide/vim-joker'
+NeoBundle 'sff1019/vim-joker'
 " Vundle
-Plugin 'whatyouhide/vim-joker'
+Plugin 'sff1019/vim-joker'
 " dein
 call dein#add('sff1019/vim-joker')
 ```


### PR DESCRIPTION
There was a small mistake at the bottom of the README. For plug, Neo and Vundle, the repo owner was documented as being `whatyouhide`, and it required the user to authenticate. I imagine the repo is private at that location, or the ownership was relinquished at some point during development. 

I simply updated the repo owner to `sff1019` (you). 

Great color scheme by the way :) 